### PR TITLE
Change scan documentation from mentioning one_page to single_page

### DIFF
--- a/endpoints/post_websites-scan.md
+++ b/endpoints/post_websites-scan.md
@@ -7,7 +7,7 @@ Trigger scan of one or more websites
 	{
 		"account_id": "<string>",
 		"website_id": "<string>",
-		"scan_type": "<enum{'one_page', 'all_pages'}>"
+		"scan_type": "<enum{'single_page', 'all_pages'}>"
 	}
 ]
 ```
@@ -15,7 +15,7 @@ Trigger scan of one or more websites
 * `account_id` is the unique identifier of the account which owns the website.
 * `website_id` is the unique identifier of website to scan.
 * `scan_type' indicates what type of scan should be run. If no value is provided the default is `all_pages`.
-  * `one_page` only scan the first page of the website, it will provide faster results but the results may not be complete.
+  * `single_page` only scan the first page of the website, it will provide faster results but the results may not be complete.
   * `all_pages` crawl and scan all pages of the website.  slower but will provide a must more complete results.
 
 At least 1 object is required in the request.
@@ -49,7 +49,7 @@ POST https://api.termly.io/v1/websites/scan
 	{
 		"account_id": "acct_1234",
 		"website_id": "web_1234",
-		"scan_type": "one_page",
+		"scan_type": "single_page",
 	}
 ]
 


### PR DESCRIPTION
When using 'one_page' as initially described, I got this error:

```
[
    {
        "_idx": 0,
        "error": "validation_error",
        "validation_errors": [
            {
                "field": "scan_type",
                "message": "must be one of: single_page, all_pages"
            }
        ]
    }
]
```